### PR TITLE
colorForPollutionPhrase function fix and tests

### DIFF
--- a/ClimateMonitorV2/public/javascripts/new_mapping.js
+++ b/ClimateMonitorV2/public/javascripts/new_mapping.js
@@ -64,10 +64,10 @@ function colorForPollutionPhrase(pm10, pm2) {
     else if (pm10 >= 50 && pm10 < 70 || pm2 >= 25 && pm2 < 35) {
         return "The pollution levels are above WHO guidelines for safe pollution, and can lead to long term health issues"
     }
-    else if (pm10 >= 70 || pm2 >= 35) {
+    else if (pm10 >= 70 && pm10 < 100 || pm2 >= 35 && pm2 < 50) {
         return "The pollution levels are above WHO guidelines for safe pollution, and can lead to long term health issues"
     }
-    else if (pm10 >= 100 || pm2 >= 50) {
+    else if (pm10 >= 100 && pm10 < 150 || pm2 >= 50 && pm2 < 75) {
         return "The pollution levels are dangerously above WHO guidelines for safe pollution, and can lead to long <b> and </b> short term health issues"
     }
     else if (pm10 >= 150 || pm2 >= 75) {

--- a/ClimateMonitorV2/test/appTest.js
+++ b/ClimateMonitorV2/test/appTest.js
@@ -32,6 +32,7 @@ describe('new_mapping handler', function () {
             result_arr.push(colorForPollutionPhrase(30,15));
             result_arr.push(colorForPollutionPhrase(100,50));
             result_arr.push(colorForPollutionPhrase(150,75));
+            result_arr.push(colorForPollutionPhrase(151,76));
 
             return result_arr;
         }, 7);
@@ -41,8 +42,9 @@ describe('new_mapping handler', function () {
         expect(results[0]).to.equal('The pollution levels are currently within WHO guidelines!');
         expect(results[1]).to.equal('The pollution levels are just above WHO guidelines for safe pollution, and can lead to long term health issues');
         expect(results[2]).to.equal('The pollution levels are above WHO guidelines for safe pollution, and can lead to long term health issues');
-        //expect(results[3]).to.equal('The pollution levels are dangerously above WHO guidelines for safe pollution, and can lead to long <b> and </b> short term health issues');
-        //expect(results[4]).to.equal('The pollution levels are <b> dangerously </b> above WHO guidelines for safe pollution, and can lead to long and short term health issues');
+        expect(results[3]).to.equal('The pollution levels are dangerously above WHO guidelines for safe pollution, and can lead to long <b> and </b> short term health issues');
+        expect(results[4]).to.equal('The pollution levels are <b> dangerously </b> above WHO guidelines for safe pollution, and can lead to long and short term health issues');
+        expect(results[5]).to.equal('The pollution levels are <b> dangerously </b> above WHO guidelines for safe pollution, and can lead to long and short term health issues');
     }).timeout(0);
 
 

--- a/ClimateMonitorV2/test/appTest.js
+++ b/ClimateMonitorV2/test/appTest.js
@@ -30,6 +30,8 @@ describe('new_mapping handler', function () {
             result_arr.push(colorForPollutionPhrase(0,0));
             result_arr.push(colorForPollutionPhrase(20,10));
             result_arr.push(colorForPollutionPhrase(30,15));
+            result_arr.push(colorForPollutionPhrase(50,25));
+            result_arr.push(colorForPollutionPhrase(70,35));
             result_arr.push(colorForPollutionPhrase(100,50));
             result_arr.push(colorForPollutionPhrase(150,75));
             result_arr.push(colorForPollutionPhrase(151,76));
@@ -42,9 +44,11 @@ describe('new_mapping handler', function () {
         expect(results[0]).to.equal('The pollution levels are currently within WHO guidelines!');
         expect(results[1]).to.equal('The pollution levels are just above WHO guidelines for safe pollution, and can lead to long term health issues');
         expect(results[2]).to.equal('The pollution levels are above WHO guidelines for safe pollution, and can lead to long term health issues');
-        expect(results[3]).to.equal('The pollution levels are dangerously above WHO guidelines for safe pollution, and can lead to long <b> and </b> short term health issues');
-        expect(results[4]).to.equal('The pollution levels are <b> dangerously </b> above WHO guidelines for safe pollution, and can lead to long and short term health issues');
-        expect(results[5]).to.equal('The pollution levels are <b> dangerously </b> above WHO guidelines for safe pollution, and can lead to long and short term health issues');
+        expect(results[3]).to.equal('The pollution levels are above WHO guidelines for safe pollution, and can lead to long term health issues');
+        expect(results[4]).to.equal('The pollution levels are above WHO guidelines for safe pollution, and can lead to long term health issues');
+        expect(results[5]).to.equal('The pollution levels are dangerously above WHO guidelines for safe pollution, and can lead to long <b> and </b> short term health issues');
+        expect(results[6]).to.equal('The pollution levels are <b> dangerously </b> above WHO guidelines for safe pollution, and can lead to long and short term health issues');
+        expect(results[7]).to.equal('The pollution levels are <b> dangerously </b> above WHO guidelines for safe pollution, and can lead to long and short term health issues');
     }).timeout(0);
 
 


### PR DESCRIPTION
## Relevant issue
Resolves https://github.com/dambem/ClimateMonitorV2/issues/40
## Description of this PR
Fixes no nupper limit on two else if values, this caused the returning on incorrect strings. Also includes the full test for the function. 
Possible improvements in the future is a re-write using a switch


## Checklist
- [x] Tests all pass
