### PR TITLE
Fix bug with navbar not selecting about page

### DIFF
--- a/ClimateMonitorV2/views/about.pug
+++ b/ClimateMonitorV2/views/about.pug
@@ -16,9 +16,9 @@ block content
         a(class="navbar-brand") SheffSense: Sheffield Climate Monitor
         div(class="collapse navbar-collapse" id="navbarNav")
             ul(class="navbar-nav")
-                li(class = "nav-item active")
+                li(class = "nav-item")
                     a(class="nav-link" href="/") Home
-                li(class="nav-item")
+                li(class="nav-item active")
                     a(class="nav-link" href="/about") About
                 li(class="nav-item")
                     a(class="nav-link" href="/detailedstats") Detailed Statistics


### PR DESCRIPTION
## Relevant issue

## Description of this PR

Fixes a bug I noticed where, when you were on the about page, the home page was still selected on the nav-bar instead.


## Checklist
- [ ] Tests all pass
