### PR TITLE
Add air quality index to pollution information

### DIFF
--- a/ClimateMonitorV2/public/javascripts/new_mapping.js
+++ b/ClimateMonitorV2/public/javascripts/new_mapping.js
@@ -226,6 +226,20 @@ function currentWeatherDisplay() {
     });
 }
 
+function currentAirQualityDisplay() {
+    const airQualityURL = "https://api.weather.com/v3/wx/globalAirQuality?geocode=53.383331,-1.466667&language=en-US&scale=DAQI&format=json&apiKey=" + config.WEATHER_COMPANY_KEY
+    $.get(airQualityURL,
+    function(airQuality){
+        const currentAQI = airQuality.globalairquality.airQualityIndex;
+        const currentCategory = airQuality.globalairquality.airQualityCategory;
+        const currentAQIColour = airQuality.globalairquality.airQualityCategoryIndexColor;
+        const currentMessage = airQuality.globalairquality.messages.General.text;
+        $('#aqi-header').css("color", '#' + currentAQIColour);
+        $('#currentAQI').html(`<u><strong>${currentAQI}</strong></u>`);
+        $('#currentCategory').html(currentCategory + ': ' + currentMessage);
+        $('#currentAQI').css("color", '#' + currentAQIColour);
+    });
+}
 // Everything required once loaded
 $(document).ready(() => {
 
@@ -326,6 +340,7 @@ $(document).ready(() => {
     })
   
     currentWeatherDisplay();
+    currentAirQualityDisplay();
   
     var pm2Chart = document.getElementById('pm2Chart').getContext('2d');
     var pm10Chart = document.getElementById('pm10Chart').getContext('2d');
@@ -721,6 +736,7 @@ $(document).ready(() => {
 
         $('#pm2averagedesc').html(colorForPollutionPhrase(0, average_pm2))
 
+        $('#aqi-header').html("Air Quality Index Average")
 
         // appends danger_level div with certain human displays
         mortality(average_pm2, average_pm10, 500, "#mortality_pm10", "The current PM10 value is expected to cause the following increases in mortality over an average of 1000 people")

--- a/ClimateMonitorV2/views/index.pug
+++ b/ClimateMonitorV2/views/index.pug
@@ -92,6 +92,10 @@ block content
                             h4(id="pm2averageheader")
                                 h6(id="pm2averagetotal")
                                 p1(id="pm2averagedesc") 
+                            hr
+                            h4(id="aqi-header")
+                                h6(id="currentAQI")
+                                p1(id="currentCategory") 
                             div(class="col-md-12" id = "healtheffects")
                     div(class="card")
                         div(class="card-body")


### PR DESCRIPTION
## Relevant issue
https://github.com/dambem/ClimateMonitorV2/issues/79

## Description of this PR

Adds info for the air quality index to the average pollution information, using data from the weather company for Sheffield city centre.

<img width="859" alt="Screenshot 2020-07-18 at 22 36 02" src="https://user-images.githubusercontent.com/52741262/87862362-1d521100-c947-11ea-8be5-9ab7c95e0565.png">


## Checklist
- [ ] Tests all pass
