### PR TITLE
Add advice for sensitive groups to air quality data

### DIFF
--- a/ClimateMonitorV2/public/javascripts/new_mapping.js
+++ b/ClimateMonitorV2/public/javascripts/new_mapping.js
@@ -273,11 +273,15 @@ function currentAirQualityDisplay() {
         const currentAQI = airQuality.globalairquality.airQualityIndex;
         const currentCategory = airQuality.globalairquality.airQualityCategory;
         const currentMessage = airQuality.globalairquality.messages.General.text;
+        const currentMessageSensitive = airQuality.globalairquality.messages['Sensitive Group'].text;
 
         // Set values for HTML attributes
         $('#aqi-header').html("Air Quality Index Average")
         $('#currentAQI').html(`<b><strong>${currentAQI}</strong></b>`);
-        $('#currentCategory').html(currentCategory + ': ' + currentMessage);
+        $('#currentCategory').html(currentCategory);
+        $('#currentMessageGeneral').html('<b>General Advice: </b>' + currentMessage);
+        $('#currentMessageSensitive').html('<b>Advice for Sensitive Groups: </b>' + currentMessageSensitive)
+
 
         // Set up gauge for AQI
         var powerGauge = gauge("#power-gauge", {

--- a/ClimateMonitorV2/views/index.pug
+++ b/ClimateMonitorV2/views/index.pug
@@ -110,6 +110,8 @@ block content
                                 div(id="power-gauge")
                                 h4(id="currentAQI")
                                 h6(id="currentCategory")
+                                h6(id="currentMessageGeneral")
+                                h6(id="currentMessageSensitive")
                             div(class="col-md-12" id = "healtheffects")
                     div(class="card")
                         div(class="card-body")


### PR DESCRIPTION
Noticed this being returned in the API call for the air quality data and thought it should be added in the interest of emphasising the negative impacts of the air quality. Also some slight rearrangement of what was already there.

<img width="574" alt="Screenshot 2020-07-31 at 19 41 31" src="https://user-images.githubusercontent.com/52741262/89066938-3ce53280-d366-11ea-874a-faf42dc26744.png">
