### PR TITLE
Move GitHub API call to backend

### DIFF
--- a/ClimateMonitorV2/public/javascripts/new_mapping.js
+++ b/ClimateMonitorV2/public/javascripts/new_mapping.js
@@ -355,97 +355,87 @@ $(document).ready(() => {
     // Activate Carousel
     $('#pythongraphslideshow').carousel({ interval: 3000 });
 
-    $.ajax({
-        url: 'https://api.github.com/repos/dambem/ClimateMonitorV2/contents/ClimateMonitorV2/public/files/images',
-        type: 'GET',
-        contentType: 'application/json',
-        password: config.GITHUB_API_TOKEN,
-        success: function (files) {
-            var images = []
+    $.get("/githubData", { key: config.GITHUB_API_TOKEN }, function(res) {
+        var images = []
+        var files = JSON.parse(res);
+        // Get image links
+        files.forEach(function (file) {
 
-            // Get image links
-            files.forEach(function (file) {
-
-                // Only extract images
-                if (file["name"].includes(".png", file["name"].length - 5)) {               
-                    
-                    console.log(`INFO: Importing ${file["name"]}...`)
-                    images.push(file['download_url'])
-
-                }
-
-            });
-            
-            if (images.length == 0) {
-                alert("WARNING: No png images were found at ClimateMonitorV2/public/files/images\nGraph carosuel will be empty")
-            }
-            
-            // Compile the indicators first
-            for (var currentCount = 1; currentCount < images.length; ++currentCount) {
-                var listItemNode = document.createElement("LI")
-                listItemNode.setAttribute("data-target", "#pythongraphslideshow")
-                listItemNode.setAttribute("data-slide-to", currentCount)
-
-                document.getElementById("graph_carousel_indicators").appendChild(listItemNode)
-            }
-
-            // Populate the carosuel
-            var altText = "Graph unavailable. Please check your GITHUB_API_TOKEN"
-            var activeImage = false
-            var imageCount = 0
-
-            images.forEach( function (image) {
-
-                if (!activeImage) {
-                    $(`#carosuel_items`).append(
-                        `
-                        <div class="carousel-item active">
-                            <a 
-                                target="_blank"
-                                href="${image}"
-                            >
-                                <img
-                                    src="${image}"
-                                    alt="${altText}"
-                                    width="100%"
-                                    height="100%"
-                                >
-                            </a>
-                        </div>
-                        `
-                    )
-                    activeImage = true
-                    imageCount++
-
-                } else {
-                    // Use a counter to make each class unique
-                    $(`#carosuel_items`).append(
-                        `
-                        <div class="carousel-item ${imageCount}">
-                            <a 
-                                target="_blank"
-                                href="${image}"
-                            >
-                                <img
-                                    src="${image}"
-                                    alt="${altText}"
-                                    width="100%"
-                                    height="100%"
-                                >
-                            </a>
-                        </div>
-                        `
-                    )
-                    imageCount++
-
-                }
+            // Only extract images
+            if (file["name"].includes(".png", file["name"].length - 5)) {               
                 
-            });
+                console.log(`INFO: Importing ${file["name"]}...`)
+                images.push(file['download_url'])
 
-        },
-        error: function (error) {
-            console.log(error)
+            }
+
+        });
+        
+        if (images.length == 0) {
+            alert("WARNING: No png images were found at ClimateMonitorV2/public/files/images\nGraph carosuel will be empty")
         }
+        
+        // Compile the indicators first
+        for (var currentCount = 1; currentCount < images.length; ++currentCount) {
+            var listItemNode = document.createElement("LI")
+            listItemNode.setAttribute("data-target", "#pythongraphslideshow")
+            listItemNode.setAttribute("data-slide-to", currentCount)
+
+            document.getElementById("graph_carousel_indicators").appendChild(listItemNode)
+        }
+
+        // Populate the carosuel
+        var altText = "Graph unavailable. Please check your GITHUB_API_TOKEN"
+        var activeImage = false
+        var imageCount = 0
+
+        images.forEach( function (image) {
+
+            if (!activeImage) {
+                $(`#carosuel_items`).append(
+                    `
+                    <div class="carousel-item active">
+                        <a 
+                            target="_blank"
+                            href="${image}"
+                        >
+                            <img
+                                src="${image}"
+                                alt="${altText}"
+                                width="100%"
+                                height="100%"
+                            >
+                        </a>
+                    </div>
+                    `
+                )
+                activeImage = true
+                imageCount++
+
+            } else {
+                // Use a counter to make each class unique
+                $(`#carosuel_items`).append(
+                    `
+                    <div class="carousel-item ${imageCount}">
+                        <a 
+                            target="_blank"
+                            href="${image}"
+                        >
+                            <img
+                                src="${image}"
+                                alt="${altText}"
+                                width="100%"
+                                height="100%"
+                            >
+                        </a>
+                    </div>
+                    `
+                )
+                imageCount++
+
+            }
+            
+        });
     })
   
     currentWeatherDisplay();

--- a/ClimateMonitorV2/routes/index.js
+++ b/ClimateMonitorV2/routes/index.js
@@ -39,20 +39,32 @@ router.get('/airQualityIndex', async function (req, res) {
     const airQualityURL = "https://api.weather.com/v3/wx/globalAirQuality?geocode=53.383331,-1.466667&language=en-US&scale=DAQI&format=json&apiKey=" + req.query.key;
     try {
         var airQualityData = await requestify.get(airQualityURL)
+        res.send(airQualityData.body)
     } catch (err){
         console.log(err);
     }
-    res.send(airQualityData.body)
 })
+
 router.get('/weatherCompanyData', async function (req, res) {
     const weatherDataURL = "https://api.weather.com/v3/wx/forecast/hourly/2day?geocode=53.383331%2C-1.466667&format=json&units=e&language=en-US&apiKey=" + req.query.key
     try {
         var weatherData = await requestify.get(weatherDataURL)
+        res.send(weatherData.body)
     } catch (err){
         console.log(err);
     }
-    res.send(weatherData.body)
 })
+
+router.get('/githubData', async function (req, res) {
+    const githubURL = 'https://api.github.com/repos/dambem/ClimateMonitorV2/contents/ClimateMonitorV2/public/files/images?password=' + req.query.key
+    try {
+        var githubData = await requestify.get(githubURL)
+        res.send(githubData.body)
+    } catch (err) {
+        console.log(err);
+    }
+})
+
 
 const getMethods = (obj) => {
     let properties = new Set()


### PR DESCRIPTION
For: https://github.com/dambem/ClimateMonitorV2/issues/127
- Moves the GitHub API call to `index.js` in the same format that the weather company API calls now have.
- Also slightly rearranges the existing calls for the weather company as I realised I was potentially trying to use data from the requests even if there was an error.